### PR TITLE
Added `p` alias to `punish`

### DIFF
--- a/cogs/Punishments.py
+++ b/cogs/Punishments.py
@@ -48,6 +48,7 @@ class Punishments(commands.Cog):
     @commands.guild_only()
     @commands.hybrid_command(
         name="punish",
+        aliases=["p"],
         description="Punish a user",
         extras={"category": "Punishments"},
         usage="punish <user> <type> <reason>",


### PR DESCRIPTION
Similar to the search command having a convenient `s` alias, I wish to have a `p` alias for punishing users.

Closes #55 
