### PR TITLE
Fix `mywarnings` staff privacy checks

### DIFF
--- a/cogs/Search.py
+++ b/cogs/Search.py
@@ -15,6 +15,7 @@ from datamodels.StaffConnections import StaffConnection
 from datamodels.Warnings import WarningItem
 from erm import check_privacy, is_staff, staff_field, staff_predicate
 from utils.autocompletes import user_autocomplete
+from copy import copy
 from utils.constants import BLANK_COLOR
 from utils.utils import invis_embed, failure_embed, get_roblox_by_username, require_settings
 from utils.paginators import SelectPagination, CustomPage
@@ -35,7 +36,7 @@ class Search(commands.Cog):
         with_app_command=True,
     )
     @require_settings()
-    async def mywarnings(self, ctx: commands.Context, user: discord.User = None):
+    async def mywarnings(self, ctx: commands.Context, user: discord.Member = None): # changing this to discord.Member, change back to discord.User in the event of error
         if user is None:
            user = ctx.author 
         guild_id = ctx.guild.id
@@ -142,7 +143,10 @@ class Search(commands.Cog):
                 inline=False,
             )
 
-        if await staff_predicate(ctx):
+        new_ctx = copy(ctx)
+        new_ctx.author = user or ctx.author
+
+        if await staff_predicate(new_ctx):
 
             moderator_id = user.id if user else ctx.author.id
 


### PR DESCRIPTION
This pull request implements a fix for the mywarnings staff privacy checks, which is currently not working as designed.


# Steps to Reproduce
1. Run `/mywarnings <member>` on a regular member, not a staff member.

# Actual Results
1. If **you** are staff, the command will go through and show you their staff moderations.
2. If **you** aren't staff, the command won't go through and say they haven't done any moderations.

# Expected Results
1. Whether you are staff or not should not matter in the scope of the command. It should show you their count of staff moderations as intended.