### PR TITLE
fix /erlc teams sort

### DIFF
--- a/cogs/ERLC.py
+++ b/cogs/ERLC.py
@@ -315,12 +315,15 @@ class ERLC(commands.Cog):
         new_keymap = dict(zip(new_maps, new_vals))
         embed2.title = f"Online Staff Members [{sum([len(i) for i in new_vals])}]"
         for key, value in new_keymap.items():
-            if (value := '\n'.join([f'[{plr.username}](https://roblox.com/users/{plr.id}/profile)' for plr in value])) not in ['', '\n']:
+            if value:
+                value_length = len(value)
+                value = '\n'.join([f'[{plr.username}](https://roblox.com/users/{plr.id}/profile)' for plr in value])
                 embed2.add_field(
-                    name=f'{key} [{len(value)}]',
+                    name=f'{key} [{value_length}]',
                     value=value,
                     inline=False
                 )
+
 
         if len(embed2.fields) == 0:
             embed2.description = "> There are no online staff members."

--- a/cogs/ERLC.py
+++ b/cogs/ERLC.py
@@ -624,7 +624,10 @@ class ERLC(commands.Cog):
                 teams[plr.team] = []
             teams[plr.team].append(plr)
 
-        for team, team_players in teams.items():
+        team_order = ["Police", "Sheriff", "Fire", "DOT", "Civilian"]
+        for team in team_order:
+            if team in teams:
+                team_players = teams[team]
             embed2.description += (
                 f"**{team} [{len(team_players)}]**\n" +
                 ', '.join([f'[{plr.username}](https://roblox.com/users/{plr.id}/profile)' for plr in team_players]) +


### PR DESCRIPTION
sorted weirdly before but now should sort by LEO, Fire, DOT, and Civilian top to bottom

looked at the word 'team' so much it no longer looks real