### PR TITLE
Add ERLC API compatability for self hosting

### DIFF
--- a/erm.py
+++ b/erm.py
@@ -175,7 +175,7 @@ class Bot(commands.AutoShardedBot):
             self.oauth2_users = OAuth2Users(self.db, "oauth2")
 
             self.roblox = roblox.Client()
-            self.prc_api = PRCApiClient(self, base_url=config('PRC_API_URL', default='https://api.policeroleplay.community/v1'), api_key=config('PRC_API_KEY', default='default_api_key'))
+            self.prc_api = PRCApiClient(self, base_url=config('PRC_API_URL', default='https://api.policeroleplay.community/v1'), api_key=config('PRC_API_KEY', default=None))
             self.bloxlink = Bloxlink(self, config('BLOXLINK_API_KEY'))
 
             Extensions = [m.name for m in iter_modules(["cogs"], prefix="cogs.")]

--- a/utils/prc_api.py
+++ b/utils/prc_api.py
@@ -119,13 +119,15 @@ class PRCApiClient:
                 internal_server_key = internal_server_key.key
         else:
             internal_server_key = key
-
-
-        async with self.session.request(method, url=f"{self.base_url}{endpoint}", headers={
-            "Authorization": self.api_key,
+        
+        headers = {
             "User-Agent": "Application",
-            "Server-Key": internal_server_key
-        }, json=data or {}) as response:
+            "Server-Key": internal_server_key,
+        }
+        if self.api_key:
+            headers["Authorization"] = self.api_key
+
+        async with self.session.request(method, url=f"{self.base_url}{endpoint}", headers=headers, json=data or {}) as response:
             # if response.status == 403:
             #     await self.bot.prohibited.insert({
             #         "_id": ObjectId(),


### PR DESCRIPTION
A affiliate server wants to use 2 ERM bots for server a and b for the API stuff and shit (They are for some reason stubborn and don't wanna make 2 servers??)