### PR TITLE
Minor Performance Update for `>erlc risk` command

### DIFF
--- a/events/on_shift_end.py
+++ b/events/on_shift_end.py
@@ -6,7 +6,6 @@ from discord.ext import commands
 from datamodels.ShiftManagement import ShiftItem
 from utils.constants import BLANK_COLOR
 from utils.timestamp import td_format
-from collections import Counter
 
 
 class OnShiftEnd(commands.Cog):
@@ -98,10 +97,14 @@ class OnShiftEnd(commands.Cog):
             except discord.HTTPException:
                 pass
 
-        moderation_counts = Counter()
-        for entry_id in shift.moderations:
-            entry = await self.bot.punishments.fetch_warning(str(entry_id))
-            moderation_counts[entry.type] += 1
+        moderation_counts = {}
+        for entry in shift.moderations:
+            entry = await self.bot.punishments.fetch_warning(str(entry))
+
+            if entry.type in moderation_counts:
+                moderation_counts[entry.type] += 1
+            else:
+                moderation_counts[entry.type] = 1
 
         if channel is not None:
             await channel.send(
@@ -127,10 +130,14 @@ class OnShiftEnd(commands.Cog):
                 .add_field(
                     name="Moderation Details:",
                     value=(
-                    "\n".join(
-                        f"> **{moderation_type.capitalize()}:** {count}"
-                        for moderation_type, count in moderation_counts.items()
-                    ) if moderation_counts else "> No Moderations Found"
+                        "\n".join(
+                            [
+                                f"> **{moderation_type.capitalize()}s:** {count}"
+                                for moderation_type, count in moderation_counts.items()
+                            ]
+                        )
+                        if moderation_counts
+                        else "> No Moderations Found"
                     ),
                     inline=False,
                 )
@@ -162,10 +169,14 @@ class OnShiftEnd(commands.Cog):
                 .add_field(
                     name="Total Moderations:",
                     value=(
-                    "\n".join(
-                        f"> **{moderation_type.capitalize()}s:** {count}"
-                        for moderation_type, count in moderation_counts.items()
-                    ) if moderation_counts else "> No Moderations Found"
+                        "\n".join(
+                            [
+                                f"> **{moderation_type.capitalize()}s:** {count}"
+                                for moderation_type, count in moderation_counts.items()
+                            ]
+                        )
+                        if moderation_counts
+                        else "> No Moderations Found"
                     ),
                     inline=False,
                 )

--- a/events/on_shift_end.py
+++ b/events/on_shift_end.py
@@ -6,6 +6,7 @@ from discord.ext import commands
 from datamodels.ShiftManagement import ShiftItem
 from utils.constants import BLANK_COLOR
 from utils.timestamp import td_format
+from collections import Counter
 
 
 class OnShiftEnd(commands.Cog):
@@ -97,14 +98,10 @@ class OnShiftEnd(commands.Cog):
             except discord.HTTPException:
                 pass
 
-        moderation_counts = {}
-        for entry in shift.moderations:
-            entry = await self.bot.punishments.fetch_warning(str(entry))
-
-            if entry.type in moderation_counts:
-                moderation_counts[entry.type] += 1
-            else:
-                moderation_counts[entry.type] = 1
+        moderation_counts = Counter()
+        for entry_id in shift.moderations:
+            entry = await self.bot.punishments.fetch_warning(str(entry_id))
+            moderation_counts[entry.type] += 1
 
         if channel is not None:
             await channel.send(
@@ -130,14 +127,10 @@ class OnShiftEnd(commands.Cog):
                 .add_field(
                     name="Moderation Details:",
                     value=(
-                        "\n".join(
-                            [
-                                f"> **{moderation_type.capitalize()}s:** {count}"
-                                for moderation_type, count in moderation_counts.items()
-                            ]
-                        )
-                        if moderation_counts
-                        else "> No Moderations Found"
+                    "\n".join(
+                        f"> **{moderation_type.capitalize()}:** {count}"
+                        for moderation_type, count in moderation_counts.items()
+                    ) if moderation_counts else "> No Moderations Found"
                     ),
                     inline=False,
                 )
@@ -169,14 +162,10 @@ class OnShiftEnd(commands.Cog):
                 .add_field(
                     name="Total Moderations:",
                     value=(
-                        "\n".join(
-                            [
-                                f"> **{moderation_type.capitalize()}s:** {count}"
-                                for moderation_type, count in moderation_counts.items()
-                            ]
-                        )
-                        if moderation_counts
-                        else "> No Moderations Found"
+                    "\n".join(
+                        f"> **{moderation_type.capitalize()}s:** {count}"
+                        for moderation_type, count in moderation_counts.items()
+                    ) if moderation_counts else "> No Moderations Found"
                     ),
                     inline=False,
                 )

--- a/menus.py
+++ b/menus.py
@@ -12425,10 +12425,10 @@ class SpecificUserSelect(discord.ui.Select):
                 color=BLANK_COLOR
             ), ephemeral=True
         )
+        ban_string = ":ban "
         for user_id in self.values:
             user_id = int(user_id)
-            ban_command = f":ban {user_id}"
-            await self.bot.prc_api.run_command(self.guild_id, ban_command)
+            ban_string += f"{user_id}, "
             user = next((u for u in self.risky_users if u.id == user_id), None)
             if user:
                 await self.bot.punishments.insert_warning(
@@ -12441,11 +12441,31 @@ class SpecificUserSelect(discord.ui.Select):
                     reason="Having a user with all or others.",
                     time_epoch=datetime.datetime.now(tz=pytz.UTC).timestamp(),
                 )
-            await asyncio.sleep(5)  # Rate limit: 1 command every 5 seconds
+        await self.bot.prc_api.run_command(self.guild_id, ban_string[:-2])
         await interaction.followup.send(
             embed=discord.Embed(
                 title=f"{await self.bot.emoji_controller.get_emoji('success')} Players Banned",
                 description="The selected players have been banned from the server.",
                 color=GREEN_COLOR
             ), ephemeral=True
+        )
+
+class DefaultPunishmentToggle(discord.ui.View):
+    def __init__(self, bot, user_id: int, sett):
+        self.bot = bot
+        self.user_id = user_id
+        self.sett = sett
+        super().__init__()
+
+    async def interaction_check(self, interaction: discord.Interaction, /) -> bool:
+        if interaction.user.id == self.user_id:
+            return True #Most probably I'm not gonna use it but yea :)
+
+        await interaction.response.send_message(
+            embed=discord.Embed(
+                title="Not Permitted",
+                description="You are not permitted to interact with these buttons.",
+                color=blank_color,
+            ),
+            ephemeral=True,
         )

--- a/menus.py
+++ b/menus.py
@@ -7859,7 +7859,7 @@ class GameLoggingConfiguration(AssociationConfigurationView):
         await interaction.response.send_message(view=new_view, ephemeral=True)
 
 
-class ExtendedERLCConfiguration(AssociationConfigurationView):
+class RDMERLCConfiguration(AssociationConfigurationView):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -7923,73 +7923,6 @@ class ExtendedERLCConfiguration(AssociationConfigurationView):
             interaction.user,
             f"RDM Alert Channel Set: <#{select.values[0].id}>",
         )
-
-    @discord.ui.select(
-        placeholder="PM on Warning",
-        row=2,
-        options=[
-            discord.SelectOption(
-                label="Enabled",
-                value="enabled",
-                description="PM on Warning is enabled.",
-            ),
-            discord.SelectOption(
-                label="Disabled",
-                value="disabled",
-                description="PM on Warning is disabled.",
-            ),
-        ],
-    )
-    async def message_on_warning(
-        self, interaction: discord.Interaction, select: discord.ui.Select
-    ):
-        value = await self.interaction_check(interaction)
-        if not value:
-            return
-
-        await interaction.response.defer()
-        guild_id = interaction.guild.id
-
-        bot = self.bot
-        sett = await bot.settings.find_by_id(guild_id)
-        if not sett.get("ERLC"):
-            sett["ERLC"] = {}
-        sett["ERLC"]["message_on_warning"] = bool(select.values[0].lower() == "enabled")
-        await bot.settings.update_by_id(sett)
-        await config_change_log(
-            self.bot,
-            interaction.guild,
-            interaction.user,
-            f"PM on Warning set: {select.values[0]}",
-        )
-
-    @discord.ui.button(label="Welcome Messaging", row=3)
-    async def welcome_messaging(
-        self, interaction: discord.Interaction, button: discord.ui.Button
-    ):
-        val = await self.interaction_check(interaction)
-        if val is False:
-            return
-
-        settings = await self.bot.settings.find_by_id(interaction.guild.id)
-        welcome_message = (settings.get("ERLC") or {}).get("welcome_message") or ""
-
-        embed = discord.Embed(
-            title="Welcome Messaging",
-            description="*This module allows for a message to appear to players of your server when they initially join your server.*\n\n",
-            color=BLANK_COLOR,
-        )
-        embed.description += f"**Welcome Message:** {welcome_message if welcome_message != '' else 'None'}\n"
-
-        embed.set_author(
-            name=interaction.guild.name,
-            icon_url=interaction.guild.icon.url if interaction.guild.icon else "",
-        )
-        view = WelcomeMessagingConfiguration(self.bot, interaction, welcome_message)
-
-        await interaction.response.send_message(embed=embed, view=view, ephemeral=True)
-
-
 class AutomaticShiftConfiguration(discord.ui.View):
     def __init__(
         self,
@@ -8657,15 +8590,15 @@ class ERLCIntegrationConfiguration(AssociationConfigurationView):
             f"Kill Logs Channel Set: <#{select.values[0].id}>",
         )
 
-    @discord.ui.button(label="More Options", row=3)
-    async def more_options(
+    @discord.ui.button(label="RDM Alerts", row=3)
+    async def rdm_alerts(
         self, interaction: discord.Interaction, button: discord.Button
     ):
         val = await self.interaction_check(interaction)
         if val is False:
             return
         sett = await self.bot.settings.find_by_id(interaction.guild.id)
-        new_view = ExtendedERLCConfiguration(
+        new_view = RDMERLCConfiguration(
             self.bot,
             interaction.user.id,
             [
@@ -8749,7 +8682,95 @@ class ERLCIntegrationConfiguration(AssociationConfigurationView):
 
         await interaction.response.send_message(embed=embed, view=view, ephemeral=True)
 
-    @discord.ui.button(label="Vehicle Restrictions", row=3)
+    @discord.ui.button(label="More Options", row=3)
+    async def more_options(self, interaction: discord.Interaction, button: discord.ui.Button):
+        val = await self.interaction_check(interaction)
+        if val is False:
+            return
+
+        view = MoreERLCConfiguration(self.bot)
+        embed = discord.Embed(
+            title="More ERLC Options",
+            description="",
+            color=BLANK_COLOR
+        )
+        await interaction.response.send_message(
+            embed=embed,
+            view=view,
+            ephemeral=True
+        )
+
+class MoreERLCConfiguration(discord.ui.View):
+    def __init__(self, bot):
+        super().__init__(timeout=None)
+        self.bot = bot
+
+    @discord.ui.select(
+        placeholder="PM on Warning",
+        row=0,
+        options=[
+            discord.SelectOption(
+                label="Enabled",
+                value="enabled",
+                description="PM on Warning is enabled.",
+            ),
+            discord.SelectOption(
+                label="Disabled",
+                value="disabled",
+                description="PM on Warning is disabled.",
+            ),
+        ],
+    )
+    async def message_on_warning(
+        self, interaction: discord.Interaction, select: discord.ui.Select
+    ):
+        value = await self.interaction_check(interaction)
+        if not value:
+            return
+
+        await interaction.response.defer()
+        guild_id = interaction.guild.id
+
+        bot = self.bot
+        sett = await bot.settings.find_by_id(guild_id)
+        if not sett.get("ERLC"):
+            sett["ERLC"] = {}
+        sett["ERLC"]["message_on_warning"] = bool(select.values[0].lower() == "enabled")
+        await bot.settings.update_by_id(sett)
+        await config_change_log(
+            self.bot,
+            interaction.guild,
+            interaction.user,
+            f"PM on Warning set: {select.values[0]}",
+        )
+
+    @discord.ui.button(label="Welcome Messaging", row=1)
+    async def welcome_messaging(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ):
+        val = await self.interaction_check(interaction)
+        if val is False:
+            return
+
+        settings = await self.bot.settings.find_by_id(interaction.guild.id)
+        welcome_message = (settings.get("ERLC") or {}).get("welcome_message") or ""
+
+        embed = discord.Embed(
+            title="Welcome Messaging",
+            description="*This module allows for a message to appear to players of your server when they initially join your server.*\n\n",
+            color=BLANK_COLOR,
+        )
+        embed.description += f"**Welcome Message:** {welcome_message if welcome_message != '' else 'None'}\n"
+
+        embed.set_author(
+            name=interaction.guild.name,
+            icon_url=interaction.guild.icon.url if interaction.guild.icon else "",
+        )
+        view = WelcomeMessagingConfiguration(self.bot, interaction, welcome_message)
+
+        await interaction.response.send_message(embed=embed, view=view, ephemeral=True)
+
+    @discord.ui.button(label="Vehicle Restrictions", row=1)
     async def vehicle_restrictions(
         self, interaction: discord.Interaction, button: discord.ui.Button
     ):
@@ -8844,7 +8865,7 @@ class ERLCIntegrationConfiguration(AssociationConfigurationView):
         )
         await interaction.response.send_message(embed=embed, view=view, ephemeral=True)
 
-    @discord.ui.button(label="ER:LC Statistics", row=3, disabled=False)
+    @discord.ui.button(label="ER:LC Statistics", row=1, disabled=False)
     async def erlc_statistics(
         self, interaction: discord.Interaction, button: discord.ui.Button
     ):


### PR DESCRIPTION
Instead of banning each userid one by one, we can just create a string like `:ban userid1, userid2,...` and ban all risky usernames at once.
This would be a better approach instead of taking 5 seconds to ban each user.