### PR TITLE
Fix: PRC Keys nolonger submitted in a way that causes 2001 Malformed …

### DIFF
--- a/utils/prc_api.py
+++ b/utils/prc_api.py
@@ -143,15 +143,22 @@ class PRCApiClient:
         else:
             internal_server_key = key
 
+
+        headers = {
+            "Server-Key": str(internal_server_key).strip(),
+            "Accept": "application/json",  
+        }
+
+        request_kwargs = {"headers": headers}
+        if method == "POST" and data is not None:
+            request_kwargs["json"] = data
+
+        url = f"{self.base_url.rstrip('/')}/{endpoint.lstrip('/')}"
+        
         async with self.session.request(
             method,
-            url=f"{self.base_url}{endpoint}",
-            headers={
-                "Authorization": self.api_key,
-                "User-Agent": "Application",
-                "Server-Key": internal_server_key,
-            },
-            json=data or {},
+            url=url,
+            **request_kwargs
         ) as response:
             # if response.status == 403:
             #     await self.bot.prohibited.insert({


### PR DESCRIPTION
…key error.

Issue: Users are unable to link Keys, or use any ERLC API dependant features.
Cause: headers in `_send_api_request(` were set & send in a way that PRC would return `2001`, `Malformed-Key`

Fix: Update headers, strip from endpoints and key for safety.


Attachments: 
- Active issue with valid Server-Key:
<img width="2133" height="1174" alt="grafik" src="https://github.com/user-attachments/assets/56b2f535-f8bf-4e8c-a909-af9339fc7fcb" />
