### PR TITLE
fix: remove duplicate erlc command group from MC cog

### DIFF
--- a/cogs/MC.py
+++ b/cogs/MC.py
@@ -64,11 +64,7 @@ class MC(commands.Cog):
             self.bot, guild_id, author_id, interpret_type, command_string, attempted
         )
 
-    @commands.hybrid_group(name="erlc")
-    async def server(self, ctx: commands.Context):
-        pass
-
-    @commands.hybrid_group(name="mc")  # hmmmm...
+    @commands.hybrid_group(name="mc")
     async def mc(self, ctx: commands.Context):
         pass
 


### PR DESCRIPTION
## Bug Fix
Fixes https://github.com/mikeywhiston/ERM/pull/196 bug, a critical `CommandRegistrationError` that prevents the bot from starting after the Maple County code was split into its own cog.
