### PR TITLE
Fix OAuth2 polling loop

### DIFF
--- a/cogs/OAuth2.py
+++ b/cogs/OAuth2.py
@@ -60,7 +60,8 @@ class OAuth2(commands.Cog):
             await msg.edit(**verification_message)
 
         attempts = 0
-        while await asyncio.sleep(3):
+        while True:
+            await asyncio.sleep(3)
             if attempts > 60:
                 break
             if not linked_account:


### PR DESCRIPTION
asyncio.sleep returns None, so the while loop never executed.