### PR TITLE
Fix ModCall dataclass fields to match API instantiation

### DIFF
--- a/cogs/ERLC.py
+++ b/cogs/ERLC.py
@@ -213,7 +213,7 @@ class ERLC(commands.Cog):
                 discord.ui.TextDisplay(
                     "\n".join(
                         [
-                            f"> Caller: {call.caller} • Moderator: {call.moderator} • <t:{call.timestamp}:F>"
+                            f"> Caller: {call.caller_username} • Moderator: {call.moderator_username or 'n/a'} • <t:{call.timestamp}:F>"
                             for call in matching_modcalls
                         ]
                     )

--- a/utils/prc_api.py
+++ b/utils/prc_api.py
@@ -76,9 +76,11 @@ class Player(BaseDataClass):
 
 
 class ModCall(BaseDataClass):
-    caller: str
-    moderator: str | None = None
+    caller_username: str
+    caller_id: str
     timestamp: int
+    moderator_username: str | None = None
+    moderator_id: str | None = None
 
 
 class ServerStatus(BaseDataClass):


### PR DESCRIPTION
ModCall dataclass defined caller and moderator fields, but get_mod_calls() instantiates it with caller_username, caller_id, moderator_username, and moderator_id, causing an AttributeError. Updated the dataclass and the player panel.