### PR TITLE
Fix undefined roblox_username when auto_punish is disabled

### DIFF
--- a/cogs/Punishments.py
+++ b/cogs/Punishments.py
@@ -102,6 +102,8 @@ class Punishments(commands.Cog):
 
         auto_punish = settings.get("ERLC", {}).get("auto_punish", False)
         present_unpermitted_warning = False
+        roblox_username = None
+        server_staff = []
         if auto_punish is True:
             server_staff = await self.bot.prc_api.get_server_staff(ctx.guild.id)
             roblox_username = await self.bot.accounts.discord_to_roblox(ctx.guild, ctx.author.id)


### PR DESCRIPTION
roblox_username and server_staff are only initialized inside the if auto_punish is true block, but can be referenced at line 226 when --ban is passed in the reason flag regardless of auto_punish. should causes a NameError. Initialize both variables with defaults before the condition.