### PR TITLE
Fail Safe Fallbacks

### DIFF
--- a/tasks/check_whitelisted_car.py
+++ b/tasks/check_whitelisted_car.py
@@ -173,6 +173,8 @@ async def get_cached_guild(bot, guild_id):
     if not guild:
         try:
             guild = await bot.fetch_guild(guild_id)
+        except discord.NotFound:
+            guild = None
         except discord.HTTPException:
             guild = None
 

--- a/tasks/iterate_conditions.py
+++ b/tasks/iterate_conditions.py
@@ -40,6 +40,8 @@ async def get_cached_guild(bot, guild_id):
     if not guild:
         try:
             guild = await bot.fetch_guild(guild_id)
+        except discord.NotFound:
+            guild = None
         except discord.HTTPException:
             return None
 

--- a/tasks/mc_discord_checks.py
+++ b/tasks/mc_discord_checks.py
@@ -44,6 +44,8 @@ async def get_cached_guild(bot, guild_id):
     if not guild:
         try:
             guild = await bot.fetch_guild(guild_id)
+        except discord.NotFound:
+            guild = None
         except discord.HTTPException:
             guild = None
 

--- a/tasks/prc_automations.py
+++ b/tasks/prc_automations.py
@@ -47,6 +47,8 @@ async def get_cached_guild(bot, guild_id):
     if not guild:
         try:
             guild = await bot.fetch_guild(guild_id)
+        except discord.NotFound:
+            guild = None
         except discord.HTTPException:
             guild = None
 

--- a/tasks/statistics_check.py
+++ b/tasks/statistics_check.py
@@ -26,7 +26,7 @@ async def get_cached_guild(bot, guild_id):
     
     try:
         guild = await bot.fetch_guild(guild_id)
-    except discord.errors.NotFound:
+    except discord.NotFound:
         guild = None
     except Exception as e:
         logging.error(f"Error fetching guild {guild_id}: {e}")

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -591,6 +591,8 @@ async def fetch_get_channel(target, identifier):
     if not channel:
         try:
             channel = await target.fetch_channel(identifier)
+        except discord.NotFound:
+            channel = None
         except discord.HTTPException as e:
             channel = None
     return channel


### PR DESCRIPTION
fallback to `discord.NotFound` if channel not accessible by the bot (QoL for logs).