### PR TITLE
increase time_converter limit to 365 days

### DIFF
--- a/events/on_command_error.py
+++ b/events/on_command_error.py
@@ -32,6 +32,22 @@ class OnCommandError(commands.Cog):
             error = error.original
             return await self.on_command_error(ctx, error)
 
+        if isinstance(error, HybridCommandError):
+            if "RemoteProtocolError: Server disconnected without sending a response." in str(error):
+                return (
+                    await ctx.reply(
+                        embed=discord.Embed(
+                            title="Connection Error",
+                            description="The server disconnected without sending a response. Your issue should be fixed if you try again.",
+                            color=BLANK_COLOR,
+                        )
+                    )
+                    if not do_not_send
+                    else None
+                )
+            error = error.original
+            return await self.on_command_error(ctx, error)
+
         if isinstance(error, commands.CommandOnCooldown):
             return (
                 await ctx.reply(
@@ -52,23 +68,6 @@ class OnCommandError(commands.Cog):
             or isinstance(error, asyncio.TimeoutError)
         ):
             return
-
-        if isinstance(
-            error, HybridCommandError
-        ) and "RemoteProtocolError: Server disconnected without sending a response." in str(
-            error
-        ):
-            return (
-                await ctx.reply(
-                    embed=discord.Embed(
-                        title="Connection Error",
-                        description="The server disconnected without sending a response. Your issue should be fixed if you try again.",
-                        color=BLANK_COLOR,
-                    )
-                )
-                if not do_not_send
-                else None
-            )
 
         if isinstance(error, httpcore.ConnectTimeout):
             return (

--- a/events/on_command_error.py
+++ b/events/on_command_error.py
@@ -28,11 +28,7 @@ class OnCommandError(commands.Cog):
         bot = self.bot
         error_id = error_gen()
 
-        if isinstance(error, commands.CommandInvokeError):
-            error = error.original
-            return await self.on_command_error(ctx, error)
-
-        if isinstance(error, HybridCommandError):
+        if isinstance(error, commands.CommandInvokeError) or isinstance(error, HybridCommandError):
             if "RemoteProtocolError: Server disconnected without sending a response." in str(error):
                 return (
                     await ctx.reply(

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -189,9 +189,9 @@ def time_converter(parameter: str) -> int:
                 number = number.replace("-", "")  # prevent those negative times!
                 if not number.strip()[-1].isdigit():
                     continue
-                if int(number.strip()) * multiplier > 15552000:
+                if int(number.strip()) * multiplier > 31536000:
                     raise OverflowError(
-                        "Time value exceeds the maximum allowed duration of 180 days."
+                        "Time value exceeds the maximum allowed duration of 365 days."
                     )
                 return int(number.strip()) * multiplier
 


### PR DESCRIPTION
increases the max allowed duration from 180 days to 365 days in time_converter. also unwraps HybridCommandError in on_command_error so OverflowError and other wrapped exceptions get handled properly.